### PR TITLE
Prevent repeated link-to-card comment adding in pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Required env variables include:
 Optional env variables include:
 
 - `TRELLO_ACTION_VERBOSE` to make action logs slightly more verbose.
-- `TRELLO_API_DEBUG` expose all API call resposes in action log.
-- `GITHUB_API_DEBUG` expose API call data in action log.
+- `TRELLO_API_DEBUG` expose Trello API call resposes in action log.
+- `GITHUB_API_DEBUG` expose Github API call data in action log.
 
 ### Pull requests and Cards referring to PR or issue
 
@@ -105,8 +105,8 @@ Optional env variables include:
 
 - `TRELLO_SOURCE_LIST_ID` The id of your Trello list (column) where you wish to limit searching the Card.
 - `TRELLO_ACTION_VERBOSE` to make action logs slightly more verbose.
-- `TRELLO_API_DEBUG` expose all API call resposes in action log.
-- `GITHUB_API_DEBUG` expose API call data in action log.
+- `TRELLO_API_DEBUG` expose Trello API call resposes in action log.
+- `GITHUB_API_DEBUG` expose Github API call data in action log.
 
 ## API key and token
 
@@ -132,5 +132,5 @@ yarn install
 yarn pre-release
 git add .
 git commit -m'Compiled new code'
-git tag -a 'Tagging new release v1.0.2' v1.0.2
+git tag -a 'Tagging new release v1.2.0' v1.2.0
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -772,7 +772,11 @@ const isIssueAlreadyLinkedTo = (findme, { issueNumber, repoOwner, repoName }) =>
         if (debug) {
             console.log('getAllIssueComments() returned data: ', JSON.stringify(comments, null, 2));
         }
-        return comments.some((comment) => comment.body && comment.body.match(findme));
+        const isLinked = comments.some((comment) => comment.body && comment.body.match(findme));
+        if (verbose) {
+            console.log(`String "${findme}" found in issue ${repoOwner}/${repoName}/${issueNumber} comments? ${isLinked ? 'yes' : 'no'}`);
+        }
+        return isLinked;
     })
         .catch((error) => {
         console.error('Error locating the provided string in issue/pr comments: ' +

--- a/dist/index.js
+++ b/dist/index.js
@@ -91,11 +91,12 @@ const getAllIssueComments = ({ issueNumber, repoOwner, repoName }) => __awaiter(
         repo: repoName,
         issue_number: issueNumber,
     };
-    // https://docs.github.com/en/rest/reference/issues#list-issue-comments
     const issueComments = yield octokit.rest.issues.listComments(ghIssueData);
-    console.log(`getAllIssueComments with issue ${issueNumber}: `);
-    console.log(JSON.stringify(issueComments, null, 2));
-    return issueComments;
+    if (debug) {
+        console.log(`getAllIssueComments with issue ${issueNumber}: `);
+        console.log(JSON.stringify(issueComments, null, 2));
+    }
+    return issueComments.data || [];
 });
 exports.getAllIssueComments = getAllIssueComments;
 //# sourceMappingURL=api-github.js.map
@@ -757,22 +758,21 @@ const isIssueAlreadyLinkedTo = (findme, { issueNumber, repoOwner, repoName }) =>
         .then((comments) => {
         // comments is array of individual comments here.
         if (!comments) {
-            debug &&
+            if (debug) {
                 console.log('getAllIssueComments() returned a falsy dataset: ', JSON.stringify(comments, null, 2));
-            return undefined;
+            }
+            return false;
         }
         else if (!comments.length) {
-            debug &&
-                console.log('getAllIssueComments() returned a empty array: ', JSON.stringify(comments, null, 2));
-            return undefined;
+            if (debug) {
+                console.log('getAllIssueComments() returned a empty array');
+            }
+            return false;
         }
-        debug &&
-            console.log('getAllIssueComments() returned a empty array: ', JSON.stringify(comments, null, 2));
+        if (debug) {
+            console.log('getAllIssueComments() returned data: ', JSON.stringify(comments, null, 2));
+        }
         return comments.some((comment) => comment.body && comment.body.match(findme));
-    })
-        .then((matcher) => {
-        debug && console.log('matcher returns: ', JSON.stringify(matcher, null, 2));
-        return matcher === undefined;
     })
         .catch((error) => {
         console.error('Error locating the provided string in issue/pr comments: ' +

--- a/src/api-github.ts
+++ b/src/api-github.ts
@@ -66,11 +66,15 @@ const getAllIssueComments = async ({ issueNumber, repoOwner, repoName }: ghIssue
     repo: repoName,
     issue_number: issueNumber,
   };
-  // https://docs.github.com/en/rest/reference/issues#list-issue-comments
+
   const issueComments = await octokit.rest.issues.listComments(ghIssueData);
-  console.log(`getAllIssueComments with issue ${issueNumber}: `);
-  console.log(JSON.stringify(issueComments, null, 2));
-  return issueComments;
+
+  if (debug) {
+    console.log(`getAllIssueComments with issue ${issueNumber}: `);
+    console.log(JSON.stringify(issueComments, null, 2));
+  }
+
+  return issueComments.data || [];
 };
 
 export { addIssueComment, getAllIssueComments };

--- a/src/api-github.ts
+++ b/src/api-github.ts
@@ -1,5 +1,5 @@
 import * as github from '@actions/github';
-import { ghIssueCommentData, ghPullRequestCommentData } from './types';
+import { ghIssueCommentData, ghIssueData } from './types';
 
 const debug: string | boolean = process.env.GITHUB_API_DEBUG || true;
 const githubToken: string | undefined = process.env.GITHUB_TOKEN;
@@ -50,4 +50,27 @@ const addIssueComment = async ({
   return true;
 };
 
-export { addIssueComment };
+/**
+ * REST endpint to get all Issue (or PR) comments.
+ *
+ * @see https://docs.github.com/en/rest/reference/issues#list-issue-comments-for-a-repository
+ */
+const getAllIssueComments = async ({ issueNumber, repoOwner, repoName }: ghIssueData) => {
+  if (!octokit) {
+    console.error('Octokit is not defined.');
+    !githubToken && console.error('GITHUB_TOKEN is falsy.');
+    return [];
+  }
+  const ghIssueData = {
+    owner: repoOwner,
+    repo: repoName,
+    issue_number: issueNumber,
+  };
+  // https://docs.github.com/en/rest/reference/issues#list-issue-comments
+  const issueComments = await octokit.rest.issues.listComments(ghIssueData);
+  console.log(`getAllIssueComments with issue ${issueNumber}: `);
+  console.log(JSON.stringify(issueComments, null, 2));
+  return issueComments;
+};
+
+export { addIssueComment, getAllIssueComments };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   addAttachmentToCard,
 } from './api-trello';
 import { TrelloCard, TrelloCardRequestParams } from './types';
-import { cardHasPrLinked, validateListExistsOnBoard } from './utils';
+import { cardHasPrLinked, isIssueAlreadyLinkedTo, validateListExistsOnBoard } from './utils';
 
 const verbose: string | boolean = process.env.TRELLO_ACTION_VERBOSE || false;
 const action = core.getInput('action');
@@ -237,22 +237,35 @@ function pullRequestEventMoveCard() {
               repoName: repository.repo,
             };
 
-            addIssueComment(commentData)
-              .then((success) => {
-                if (success) {
-                  verbose &&
-                    console.log(`Link to the Trello Card added to the PR: ${card.shortUrl}`);
-                } else {
+            // Spread and desctruction of an object property.
+            const { comment, ...issueLocator } = commentData;
+
+            if (!isIssueAlreadyLinkedTo(card.shortUrl, issueLocator)) {
+              addIssueComment(commentData)
+                .then((success) => {
+                  if (success) {
+                    verbose &&
+                      console.log(`Link to the Trello Card added to the PR: ${card.shortUrl}`);
+                  } else {
+                    console.error(`Non-fatal error: Failed to add link to the Trello card.`);
+                  }
+                })
+                .catch(() => {
                   console.error(`Non-fatal error: Failed to add link to the Trello card.`);
-                }
-              })
-              .catch(() => {
-                console.error(`Non-fatal error: Failed to add link to the Trello card.`);
-              });
+                });
+            } else {
+              if (verbose) {
+                console.log(
+                  `Link to the Trello Card was found in the comments, so adding it was skipped.`,
+                );
+              }
+            }
           })
           .catch((error) => {
             console.error(error);
-            core.setFailed('Something went wrong when querying Cards to be moved.');
+            core.setFailed(
+              'Something went wrong when updating Cards to be moved to some new column.',
+            );
             return [];
           });
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,16 +119,50 @@ interface TrelloCardRequestParams {
   destinationListId?: string;
 }
 
-interface ghCommentData {
-  comment: string;
+interface ghBaseData {
   repoOwner: string;
   repoName: string;
+}
+interface ghCommentData extends ghBaseData {
+  comment: string;
+}
+interface ghIssueData extends ghBaseData {
+  issueNumber: number;
 }
 interface ghIssueCommentData extends ghCommentData {
   issueNumber: number;
 }
-interface ghPullRequestCommentData extends ghCommentData {
-  pullNumber: number;
+
+interface ghResponseIssueComment {
+  id: number;
+  node_id: string;
+  url: string;
+  html_url: string;
+  body: string;
+  user: {
+    login: string;
+    id: number;
+    node_id: string;
+    avatar_url: string;
+    gravatar_id: string;
+    url: string;
+    html_url: string;
+    followers_url: string;
+    following_url: string;
+    gists_url: string;
+    starred_url: string;
+    subscriptions_url: string;
+    organizations_url: string;
+    repos_url: string;
+    events_url: string;
+    received_events_url: string;
+    type: string;
+    site_admin: boolean;
+  };
+  created_at: string;
+  updated_at: string;
+  issue_url: string;
+  author_association: string;
 }
 
 export {
@@ -139,5 +173,6 @@ export {
   TrelloAttachment,
   TrelloCardRequestParams,
   ghIssueCommentData,
-  ghPullRequestCommentData,
+  ghIssueData,
+  ghResponseIssueComment,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
+import { getAllIssueComments } from './api-github';
 import { getCardAttachments, getListsOnBoard } from './api-trello';
-import { TrelloCard } from './types';
+import { ghIssueData, TrelloCard } from './types';
 
 const verbose: string | boolean = process.env.TRELLO_ACTION_VERBOSE || false;
 
@@ -70,4 +71,33 @@ const cardHasPrLinked = (card: TrelloCard, repoHtmlUrl: string) => {
   });
 };
 
-export { validateIdPattern, validateListExistsOnBoard, boardId, cardHasPrLinked };
+const isIssueAlreadyLinkedTo = (
+  findme: string,
+  { issueNumber, repoOwner, repoName }: ghIssueData,
+): Promise<boolean | void> => {
+  return getAllIssueComments({ issueNumber: issueNumber, repoOwner: repoOwner, repoName: repoName })
+    .then((comments) => {
+      if (!comments || !comments.length) {
+        return undefined;
+      }
+      // TEMP for debugging.
+      return undefined;
+      // return comments.some((comment) => comment.body && comment.body.match(findme));
+    })
+    .then((matcher) => {
+      return matcher === undefined;
+    })
+    .catch((error) => {
+      console.error(
+        'Error locating the provided string in issue/pr comments: ' +
+          JSON.stringify(error, null, 2),
+      );
+    });
+};
+export {
+  validateIdPattern,
+  validateListExistsOnBoard,
+  boardId,
+  cardHasPrLinked,
+  isIssueAlreadyLinkedTo,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,33 +80,25 @@ const isIssueAlreadyLinkedTo = (
     .then((comments) => {
       // comments is array of individual comments here.
       if (!comments) {
-        debug &&
+        if (debug) {
           console.log(
             'getAllIssueComments() returned a falsy dataset: ',
             JSON.stringify(comments, null, 2),
           );
-        return undefined;
-      } else if (!(comments as []).length) {
-        debug &&
-          console.log(
-            'getAllIssueComments() returned a empty array: ',
-            JSON.stringify(comments, null, 2),
-          );
-        return undefined;
+        }
+        return false;
+      } else if (!comments.length) {
+        if (debug) {
+          console.log('getAllIssueComments() returned a empty array');
+        }
+        return false;
       }
-      debug &&
-        console.log(
-          'getAllIssueComments() returned a empty array: ',
-          JSON.stringify(comments, null, 2),
-        );
-
+      if (debug) {
+        console.log('getAllIssueComments() returned data: ', JSON.stringify(comments, null, 2));
+      }
       return (comments as []).some(
         (comment: ghResponseIssueComment) => comment.body && comment.body.match(findme),
       );
-    })
-    .then((matcher) => {
-      debug && console.log('matcher returns: ', JSON.stringify(matcher, null, 2));
-      return matcher === undefined;
     })
     .catch((error) => {
       console.error(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,9 +96,20 @@ const isIssueAlreadyLinkedTo = (
       if (debug) {
         console.log('getAllIssueComments() returned data: ', JSON.stringify(comments, null, 2));
       }
-      return (comments as []).some(
+
+      const isLinked = (comments as []).some(
         (comment: ghResponseIssueComment) => comment.body && comment.body.match(findme),
       );
+
+      if (verbose) {
+        console.log(
+          `String "${findme}" found in issue ${repoOwner}/${repoName}/${issueNumber} comments? ${
+            isLinked ? 'yes' : 'no'
+          }`,
+        );
+      }
+
+      return isLinked;
     })
     .catch((error) => {
       console.error(


### PR DESCRIPTION
This PR checks if PR already has a comment which links to related Trello card. 

Check is done using the trello card's short url, which is also used to create 
a markdown link (`[card label](short url)`). 

- Add finder&matcher to locate previous Trello card links (with short url)
- Log debug data if requested
- Compiled code for v1.1.1-beta
- Move all debug data behind debug flag, fix is-linked logic
- Add link check result logging when in verbose mode
